### PR TITLE
fix for Python 3.9+

### DIFF
--- a/cynetworkx/algorithms/dag.py
+++ b/cynetworkx/algorithms/dag.py
@@ -20,7 +20,14 @@ to the user to check for that.
 """
 
 from collections import defaultdict
-from fractions import gcd
+
+import fractions
+
+if 'gcd' in dir(fractions):
+  from fractions import gcd
+else:
+  from math import gcd
+
 from functools import partial
 from itertools import chain
 from itertools import product


### PR DESCRIPTION
fractions.gcd() was deprecated in Python 3.9 for math.gcd().  This fix looks for fractions.gcd() and if it can't find it, get gcd() from math