### PR TITLE
fix python 3.10

### DIFF
--- a/cynetworkx/algorithms/dag.py
+++ b/cynetworkx/algorithms/dag.py
@@ -20,7 +20,14 @@ to the user to check for that.
 """
 
 from collections import defaultdict
-from fractions import gcd
+import fractions
+
+if 'gcd' in dir(fractions):
+  from fractions import gcd
+else:
+  from math import gcd
+
+
 from functools import partial
 from itertools import chain
 from itertools import product

--- a/cynetworkx/algorithms/lowest_common_ancestors.py
+++ b/cynetworkx/algorithms/lowest_common_ancestors.py
@@ -10,7 +10,12 @@
 #
 # Author:  Alex Roper <aroper@umich.edu>
 """Algorithms for finding the lowest common ancestor of trees and DAGs."""
-from collections import defaultdict, Mapping, Set
+from collections import defaultdict
+try:
+    from collections.abc import Mapping, Set
+except ImportError:
+    from collections import Mapping, Set
+
 from itertools import chain, count
 
 import cynetworkx as nx

--- a/cynetworkx/classes/coreviews.py
+++ b/cynetworkx/classes/coreviews.py
@@ -10,7 +10,10 @@
 #          Dan Schult(dschult@colgate.edu)
 """
 """
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 import cynetworkx as nx
 
 __all__ = ['AtlasView', 'AdjacencyView', 'MultiAdjacencyView',

--- a/cynetworkx/classes/graph.py
+++ b/cynetworkx/classes/graph.py
@@ -20,8 +20,10 @@ For directed graphs see DiGraph and MultiDiGraph.
 from __future__ import division
 import warnings
 from copy import deepcopy
-from collections import Mapping
-
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 import cynetworkx as nx
 from cynetworkx.classes.coreviews import AtlasView, AdjacencyView
 from cynetworkx.classes.reportviews import NodeView, EdgeView, DegreeView

--- a/cynetworkx/classes/graphviews.py
+++ b/cynetworkx/classes/graphviews.py
@@ -45,8 +45,11 @@ the chain is tricky and much harder with restricted_views than
 with induced subgraphs.
 Often it is easiest to use `.copy()` to avoid chains.
 """
-from collections import Mapping
 
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from cynetworkx.classes import Graph, DiGraph, MultiGraph, MultiDiGraph
 from cynetworkx.classes.coreviews import ReadOnlyGraph, \
     AtlasView, AdjacencyView, MultiAdjacencyView, \

--- a/cynetworkx/classes/reportviews.py
+++ b/cynetworkx/classes/reportviews.py
@@ -92,7 +92,10 @@ EdgeDataView
 
     The argument `nbunch` restricts edges to those incident to nodes in nbunch.
 """
-from collections import Mapping, Set, Iterable
+try:
+    from collections.abc import Mapping, Set
+except ImportError:
+    from collections import Mapping, Set
 import cynetworkx as nx
 
 __all__ = ['NodeView', 'NodeDataView',


### PR DESCRIPTION
fractions.gcd() was deprecated 
Mapping, Set was moved  from collections to collections.abc  
